### PR TITLE
Update traefik.yml

### DIFF
--- a/compose/socket-proxy.yml
+++ b/compose/socket-proxy.yml
@@ -1,22 +1,14 @@
 services:
-  socket-proxy:
-    container_name: ${SERVICES_SOCKET_PROXY_CONTAINER_NAME:-socket-proxy}
-    env_file: ${ABSOLUTE_PATH}/data/socket-proxy/.env
-    hostname: ${SERVICES_SOCKET_PROXY_HOSTNAME:-socket-proxy}
-    healthcheck:
-      test: ["CMD-SHELL", "curl -s -o /dev/null -w '%{http_code}' http://localhost:2375 | grep -q '403' || exit 1"]
-      timeout: 1s
-      interval: 10s
-      retries: 3
-      start_period: 10s
-    image: ${SERVICES_SOCKET_PROXY_IMAGE:-lscr.io/linuxserver/socket-proxy}:${SERVICES_SOCKET_PROXY_IMAGE_VERSION:-latest}
+  traefik_crowdsec_bouncer:
+    container_name: ${SERVICES_TRAEFIK_CROWDSEC_BOUNCER_CONTAINER_NAME:-traefik_crowdsec_bouncer}
+    depends_on:
+      crowdsec:
+        condition: service_healthy
+    env_file: ${ABSOLUTE_PATH}/data/traefik-crowdsec-bouncer/.env
+    hostname: ${SERVICES_TRAEFIK_CROWDSEC_BOUNCER_HOSTNAME:-traefik-crowdsec-bouncer}
+    image: ${SERVICES_TRAEFIK_CROWDSEC_BOUNCER_IMAGE:-fbonalair/traefik-crowdsec-bouncer}:${SERVICES_TRAEFIK_CROWDSEC_BOUNCER_IMAGE_VERSION:-latest}
     networks:
-      socket_proxy:
-        ipv4_address: ${SERVICES_SOCKET_PROXY_NETWORKS_SOCKET_PROXY_IPV4:-172.31.255.254}
-        ipv6_address: ${SERVICES_SOCKET_PROXY_NETWORKS_SOCKET_PROXY_IPV6:-fd00:1:be:a:7001:0:3e:8fff}
-    read_only: true
+      crowdsec:
+        ipv4_address: ${SERVICES_TRAEFIK_CROWDSEC_BOUNCER_NETWORKS_CROWDSEC_IPV4:-172.31.127.252}
+        ipv6_address: ${SERVICES_TRAEFIK_CROWDSEC_BOUNCER_NETWORKS_CROWDSEC_IPV6:-fd00:1:be:a:7001:0:3e:6ffd}
     restart: unless-stopped
-    tmpfs:
-      - /run
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/compose/traefik.yml
+++ b/compose/traefik.yml
@@ -17,14 +17,14 @@ services:
     image: ${SERVICES_TRAEFIK_IMAGE:-traefik}:${SERVICES_TRAEFIK_IMAGE_VERSION:-3.1}
     labels:
       traefik.enable: "true"
-      traefik.http.routers.traefik-dashboad.entrypoints: websecure
-      traefik.http.routers.traefik-dashboad.middlewares: default@file, traefik-dashboard-auth@file
-      traefik.http.routers.traefik-dashboad.rule: ${SERVICES_TRAEFIK_LABELS_TRAEFIK_HOST:-HOST(`traefik.yourdomain.com`)}
-      traefik.http.routers.traefik-dashboad.service: api@internal
-      traefik.http.routers.traefik-dashboad.tls: "true"
-      traefik.http.routers.traefik-dashboad.tls.certresolver: tls_resolver
-      traefik.http.services.traefik-dashboad.loadbalancer.sticky.cookie.httpOnly: "true"
-      traefik.http.services.traefik-dashboad.loadbalancer.sticky.cookie.secure: "true"
+      traefik.http.routers.traefik-dashboard.entrypoints: websecure
+      traefik.http.routers.traefik-dashboard.middlewares: default@file, traefik-dashboard-auth@file
+      traefik.http.routers.traefik-dashboard.rule: ${SERVICES_TRAEFIK_LABELS_TRAEFIK_HOST:-HOST(`traefik.yourdomain.com`)}
+      traefik.http.routers.traefik-dashboard.service: api@internal
+      traefik.http.routers.traefik-dashboard.tls: "true"
+      traefik.http.routers.traefik-dashboard.tls.certresolver: tls_resolver
+      traefik.http.services.traefik-dashboard.loadbalancer.sticky.cookie.httpOnly: "true"
+      traefik.http.services.traefik-dashboard.loadbalancer.sticky.cookie.secure: "true"
       traefik.http.routers.pingweb.rule: PathPrefix(`/ping`)
       traefik.http.routers.pingweb.service: ping@internal
       traefik.http.routers.pingweb.entrypoints: websecure

--- a/compose/traefik.yml
+++ b/compose/traefik.yml
@@ -14,7 +14,7 @@ services:
       interval: 10s
       retries: 3
       start_period: 10s
-    image: ${SERVICES_TRAEFIK_IMAGE:-traefik}:${SERVICES_TRAEFIK_IMAGE_VERSION:-3.1}
+    image: ${SERVICES_TRAEFIK_IMAGE:-traefik}:${SERVICES_TRAEFIK_IMAGE_VERSION:-3.3}
     labels:
       traefik.enable: "true"
       traefik.http.routers.traefik-dashboard.entrypoints: websecure
@@ -54,7 +54,7 @@ services:
       - /etc/localtime:/etc/localtime:ro
       - ${ABSOLUTE_PATH}/data/traefik/traefik.yml:/etc/traefik/traefik.yml
       - ${ABSOLUTE_PATH}/data/traefik/.htpasswd:/etc/traefik/.htpasswd
-      - ${ABSOLUTE_PATH}/data/traefik/certs/acme_letsencrypt.json:/etc/traefik//acme_letsencrypt.json
+      - ${ABSOLUTE_PATH}/data/traefik/certs/acme_letsencrypt.json:/etc/traefik/acme_letsencrypt.json
       - ${ABSOLUTE_PATH}/data/traefik/certs/tls_letsencrypt.json:/etc/traefik/tls_letsencrypt.json
       - ${ABSOLUTE_PATH}/data/traefik/dynamic_conf:/etc/traefik/dynamic_conf:ro
       - /var/log/traefik/:/var/log/traefik/

--- a/data/traefik/dynamic_conf/http.middlewares.traefik-bouncer.yml.sample
+++ b/data/traefik/dynamic_conf/http.middlewares.traefik-bouncer.yml.sample
@@ -1,6 +1,6 @@
 http:
   middlewares:
     traefik-bouncer:
-      forwardauth:
+      forwardAuth:
         address: http://traefik-crowdsec-bouncer:8080/api/v1/forwardAuth
         trustForwardHeader: true


### PR DESCRIPTION
korrektur "dashboa'r'd"

Bonus:
beim Erstellen des API Key für CrowdSec steht in der GoNeuland Anleitung:
BOUNCER_PASSWORD=$(openssl rand -base64 48 | tr -dc 'a-zA-Z0-9!@#$%^&*()-_=+[]{}<>?|')
echo "BOUNCER_KEY_TRAEFIK=\"$BOUNCER_PASSWORD\"" >> /opt/containers/traefik-crowdsec-stack/.env
echo "Generated BOUNCER_KEY_TRAEFIK: $BOUNCER_PASSWORD"


In der install.sh steht es aber richtig:
# Bouncer-Passwörter generieren
show_step $current_step $total_steps "Generiere Bouncer-Passwörter"
BOUNCER_KEY_TRAEFIK_PASSWORD=$(openssl rand -base64 48 | tr -dc 'a-zA-Z0-9!@#$%^&*()-_=+[]{}<>?|')
echo -e "\nBOUNCER_KEY_TRAEFIK=$BOUNCER_KEY_TRAEFIK_PASSWORD" >> ${SCRIPT_DIR}/.env
sleep 3
BOUNCER_KEY_FIREWALL_PASSWORD=$(openssl rand -base64 48 | tr -dc 'a-zA-Z0-9!@#$%^&*()-_=+[]{}<>?|')
echo "BOUNCER_KEY_FIREWALL=$BOUNCER_KEY_FIREWALL_PASSWORD" >> ${SCRIPT_DIR}/.env
step_done "Bouncer-Passwörter generiert"
((current_step++))


es geht um das "\n" welches eine Zeile in der Datei einfügt.
Bei der Anleitung auf der Seite ist es so, dass die Variable direkt hinter der letzten Zeile eingefügt wird.


Vielen Dank für die starken Anleitungen.
Hab direkt das große Abo genommen :)