### PR TITLE
Fix: Add journald log acquisition example for Debian 12 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Fügen Sie Ihre SSL-Zertifikats-E-Mail-Adresse und die gewünschte Domain für d
     labels:
       type: traefik
     ---
+    source: journalctl
+    journalctl_filter:
+     - "_SYSTEMD_UNIT=ssh.service"
+    labels:
+      type: syslog
     ```
 
 3. Token generieren für den CrowdSec Bouncer für Trafik


### PR DESCRIPTION
Fix: Update acquis.yaml to use journald instead of missing syslog files on Debian 12

# 📄 Description 

On Debian 12 i'm facing the following error:

> time="2025-04-28T10:28:07+02:00" level=info msg="Adding file /var/log/auth.log to datasources" type=file
> time="2025-04-28T10:28:07+02:00" level=warning msg="No matching files for pattern /var/log/syslog" type=file
> time="2025-04-28T10:28:07+02:00" level=warning msg="No matching files for pattern /var/log/traefik/access.log" type=file
> time="2025-04-28T10:28:07+02:00" level=info msg="Starting processing data"
> time="2025-04-28T10:28:07+02:00" level=warning msg="/var/log/auth.log is a directory, ignoring it." type=file

This pull request updates the documentation (README.md) to address this issue and properly support Debian 12 and newer distributions that use systemd's journald for log management instead of traditional file-based logs like /var/log/syslog and /var/log/auth.log.


**Changes made:** 
 
- Extended  readme.md with a journalctl source configuration example, as recommended by https://docs.crowdsec.net/docs/data_sources/journald/.
 
# 🔍 Reason for Change 

On Debian 12 and similar systemd-based systems:

- /var/log/syslog and /var/log/auth.log do not exist by default.

- CrowdSec emits warnings about missing files and cannot monitor authentication or system events properly.

- journalctl is the current best-practice for log acquisition.

This update ensures that users of the traefik-crowdsec-stack have clear guidance for configuring log acquisition reliably on modern operating systems.