### PR TITLE
Update default Traefik image version to 3.6.1

### DIFF
--- a/compose/traefik.yml
+++ b/compose/traefik.yml
@@ -14,7 +14,7 @@ services:
       interval: 10s
       retries: 3
       start_period: 10s
-    image: ${SERVICES_TRAEFIK_IMAGE:-traefik}:${SERVICES_TRAEFIK_IMAGE_VERSION:-3.3}
+    image: ${SERVICES_TRAEFIK_IMAGE:-traefik}:${SERVICES_TRAEFIK_IMAGE_VERSION:-3.6.1}
     labels:
       traefik.enable: "true"
       traefik.http.routers.traefik-dashboard.entrypoints: websecure

--- a/compose/traefik.yml
+++ b/compose/traefik.yml
@@ -14,7 +14,7 @@ services:
       interval: 10s
       retries: 3
       start_period: 10s
-    image: ${SERVICES_TRAEFIK_IMAGE:-traefik}:${SERVICES_TRAEFIK_IMAGE_VERSION:-3.6.1}
+    image: ${SERVICES_TRAEFIK_IMAGE:-traefik}:${SERVICES_TRAEFIK_IMAGE_VERSION:-3.6}
     labels:
       traefik.enable: "true"
       traefik.http.routers.traefik-dashboard.entrypoints: websecure


### PR DESCRIPTION
Traefik Image 3.3 replaced with 3.6.1 which was released in November 2026. 3.3 caused issues with the stack in Debian environments.